### PR TITLE
remove headless option for setup command

### DIFF
--- a/packer/scripts/setup_db.sh
+++ b/packer/scripts/setup_db.sh
@@ -10,7 +10,7 @@ setup_db() {
                 $APP_PYENV_PATH/bin/cloud-inquisitor db upgrade
                 echo ''
                 echo \"Ignore line above about 'Failed loading configuration from database.' It was buffered before creating DB\"
-                $APP_PYENV_PATH/bin/cloud-inquisitor setup --headless
+                $APP_PYENV_PATH/bin/cloud-inquisitor setup
 }
 
 setup_db


### PR DESCRIPTION
Following the packer AMI build process fails because too many options are passed to the cli tool:

```
$ packer build -only ami -var-file variables/cinq-test.json build.json
...
    ami: [05:21:45] cloud_inquisitor Imported template unattached_ebs_volume.txt
    ami: usage: cloud-inquisitor [-?]
    ami:                         {db,runserver,drop_db,auth,list_plugins,import-saml,setup,scheduler,userdata,worker,shell}
    ami:                         ...
    ami: cloud-inquisitor: error: too many arguments
...
```

removing `--headless` appears to fix the issue